### PR TITLE
FIX: 'surround run' on Windows (build & dev)

### DIFF
--- a/surround/cli.py
+++ b/surround/cli.py
@@ -193,7 +193,7 @@ def run_locally(args):
         task = 'list'
 
     print("Project tasks:")
-    run_process = subprocess.Popen(['python3', '-m', 'doit', task])
+    run_process = subprocess.Popen([sys.executable, '-m', 'doit', task])
     run_process.wait()
 
 def run_as_web():

--- a/surround/config.py
+++ b/surround/config.py
@@ -1,5 +1,6 @@
 import ast
 import os
+from pathlib import Path
 from collections.abc import Mapping
 from pkg_resources import resource_stream
 
@@ -14,6 +15,16 @@ class Config(Mapping):
 
         # Set framework paths
         if project_root:
+            # Resolve absolute path
+            project_root = str(Path(project_root).resolve())
+
+            # If the system has a drive letter, change the project_root to /c/rest/of/path
+            split_path = os.path.splitdrive(project_root)
+            if split_path[0] != '':
+                drive_letter = split_path[0][0].lower()
+                path = split_path[1].replace('\\', '/')
+                project_root = '/' + drive_letter + path
+
             self._storage["project_root"] = project_root
             self._storage["package_path"] = package_path
             self._storage["output_path"] = os.path.join(project_root, "output")

--- a/templates/new/dodo.py.txt
+++ b/templates/new/dodo.py.txt
@@ -5,6 +5,15 @@ CONFIG = Config(os.path.dirname(__file__))
 DOIT_CONFIG = {{'verbosity':2}}
 IMAGE = "%s/%s:%s" % (CONFIG["company"], CONFIG["image"], CONFIG["version"])
 
+split_path = os.path.splitdrive(CONFIG["project_root"])
+
+# If the system has a drive letter, change the project_root to /c/rest/of/path
+if (split_path[0] != ''):
+    drive_letter = split_path[0][0].lower()
+    path = split_path[1].replace('\\', '/')
+
+    CONFIG.read_from_dict({{"project_root": '/' + drive_letter + path}})
+
 def task_build():
     """Build the Docker image for the current project"""
     return {{
@@ -20,7 +29,7 @@ def task_remove():
 def task_dev():
     """Run the main task for the project"""
     return {{
-        'actions': ["docker run --volume %s/:/app %s" % (CONFIG["project_root"], IMAGE)]
+        'actions': ["docker run --volume \"%s/\":/app %s" % (CONFIG["project_root"], IMAGE)]
     }}
 
 def task_prod():

--- a/templates/new/dodo.py.txt
+++ b/templates/new/dodo.py.txt
@@ -1,7 +1,8 @@
 import os
 from surround import Config
+from pathlib import Path
 
-CONFIG = Config(os.path.dirname(__file__))
+CONFIG = Config(str(Path(os.path.dirname(__file__)).resolve()))
 DOIT_CONFIG = {{'verbosity':2}}
 IMAGE = "%s/%s:%s" % (CONFIG["company"], CONFIG["image"], CONFIG["version"])
 

--- a/templates/new/dodo.py.txt
+++ b/templates/new/dodo.py.txt
@@ -1,19 +1,9 @@
 import os
 from surround import Config
-from pathlib import Path
 
-CONFIG = Config(str(Path(os.path.dirname(__file__)).resolve()))
+CONFIG = Config(os.path.dirname(__file__))
 DOIT_CONFIG = {{'verbosity':2}}
 IMAGE = "%s/%s:%s" % (CONFIG["company"], CONFIG["image"], CONFIG["version"])
-
-split_path = os.path.splitdrive(CONFIG["project_root"])
-
-# If the system has a drive letter, change the project_root to /c/rest/of/path
-if (split_path[0] != ''):
-    drive_letter = split_path[0][0].lower()
-    path = split_path[1].replace('\\', '/')
-
-    CONFIG.read_from_dict({{"project_root": '/' + drive_letter + path}})
 
 def task_build():
     """Build the Docker image for the current project"""


### PR DESCRIPTION
Fixes issue #115 
Also fixes `surround run dev` on Windows. Users must make sure the Docker daemon has been started first though and their surround project is located somewhere inside `C:/Users/` otherwise they will need to share the drive they're using in VirtualBox. See [here](https://medium.com/@Charles_Stover/fixing-volumes-in-docker-toolbox-4ad5ace0e572) for more information.

**Needs** testing on Linux and MacOS!