### PR TITLE
FIX: Create volume_path config attribute & mount volumes

### DIFF
--- a/surround/config.py
+++ b/surround/config.py
@@ -17,16 +17,18 @@ class Config(Mapping):
         if project_root:
             # Resolve absolute path
             project_root = str(Path(project_root).resolve())
+            volume_path = project_root
 
-            # If the system has a drive letter, change the project_root to /c/rest/of/path
+            # If the system has a drive letter, set volume_path to /c/rest/of/path
             split_path = os.path.splitdrive(project_root)
             if split_path[0] != '':
                 drive_letter = split_path[0][0].lower()
                 path = split_path[1].replace('\\', '/')
-                project_root = '/' + drive_letter + path
+                volume_path = '/' + drive_letter + path
 
             self._storage["project_root"] = project_root
             self._storage["package_path"] = package_path
+            self._storage["volume_path"] = volume_path
             self._storage["output_path"] = os.path.join(project_root, "output")
             self._storage["data_path"] = os.path.join(project_root, "data")
             self._storage["models_path"] = os.path.join(project_root, "models")

--- a/templates/new/dodo.py.txt
+++ b/templates/new/dodo.py.txt
@@ -32,12 +32,18 @@ def task_prod():
 
 def task_train():
     """Run training mode inside the container"""
+    output_path = CONFIG["volume_path"] + "/output"
+    data_path = CONFIG["volume_path"] + "/data"
+
     return {{
-        'actions': ["docker run %s python3 -m {project_name} --mode train" % IMAGE]
+        'actions': ["docker run --volume \"%s\":/app/output --volume \"%s\":/app/data %s python3 -m {project_name} --mode train" % (output_path, data_path, IMAGE)]
     }}
 
 def task_batch():
     """Run batch mode inside the container"""
+    output_path = CONFIG["volume_path"] + "/output"
+    data_path = CONFIG["volume_path"] + "/data"
+
     return {{
-        'actions': ["docker run %s python3 -m {project_name} --mode batch" % IMAGE]
+        'actions': ["docker run --volume \"%s\":/app/output --volume \"%s\":/app/data %s python3 -m {project_name} --mode batch" % (output_path, data_path, IMAGE)]
     }}

--- a/templates/new/dodo.py.txt
+++ b/templates/new/dodo.py.txt
@@ -20,7 +20,7 @@ def task_remove():
 def task_dev():
     """Run the main task for the project"""
     return {{
-        'actions': ["docker run --volume \"%s/\":/app %s" % (CONFIG["project_root"], IMAGE)]
+        'actions': ["docker run --volume \"%s/\":/app %s" % (CONFIG["volume_path"], IMAGE)]
     }}
 
 def task_prod():

--- a/templates/new/web_dodo.py.txt
+++ b/templates/new/web_dodo.py.txt
@@ -20,7 +20,7 @@ def task_remove():
 def task_dev():
     """Run the main task for the project"""
     return {{
-        'actions': ["docker run --volume \"%s/\":/app %s" % (CONFIG["project_root"], IMAGE)]
+        'actions': ["docker run --volume \"%s/\":/app %s" % (CONFIG["volume_path"], IMAGE)]
     }}
 
 def task_prod():

--- a/templates/new/web_dodo.py.txt
+++ b/templates/new/web_dodo.py.txt
@@ -32,14 +32,20 @@ def task_prod():
 
 def task_train():
     """Run training mode inside the container"""
+    output_path = CONFIG["volume_path"] + "/output"
+    data_path = CONFIG["volume_path"] + "/data"
+
     return {{
-        'actions': ["docker run %s python3 -m {project_name} --mode train" % IMAGE]
+        'actions': ["docker run --volume \"%s\":/app/output --volume \"%s\":/app/data %s python3 -m {project_name} --mode train" % (output_path, data_path, IMAGE)]
     }}
 
 def task_batch():
     """Run batch mode inside the container"""
+    output_path = CONFIG["volume_path"] + "/output"
+    data_path = CONFIG["volume_path"] + "/data"
+
     return {{
-        'actions': ["docker run %s python3 -m {project_name} --mode batch" % IMAGE]
+        'actions': ["docker run --volume \"%s\":/app/output --volume \"%s\":/app/data %s python3 -m {project_name} --mode batch" % (output_path, data_path, IMAGE)]
     }}
 
 def task_web():


### PR DESCRIPTION
Fixes issue #121 
Also mounts `/data` and `/output` when running `train` and `batch` tasks so the results can be accessed on the host machine.

Tested on Windows, needs testing on MacOS and Linux