### PR TITLE
FIX: Ensure container is stopped when CTRL+C is used 

### DIFF
--- a/templates/new/dodo.py.txt
+++ b/templates/new/dodo.py.txt
@@ -1,10 +1,26 @@
 import os
 import sys
+import subprocess
 from surround import Config
+from doit.tools import LongRunning
 
 CONFIG = Config(os.path.dirname(__file__))
 DOIT_CONFIG = {{'verbosity':2}}
 IMAGE = "%s/%s:%s" % (CONFIG["company"], CONFIG["image"], CONFIG["version"])
+
+def kill_container():
+    # Generate a kill list 
+    kill_list = subprocess.check_output(["docker", "ps", "-q", "-f", "ancestor=%s" % IMAGE], shell=True)
+    
+    if kill_list:
+        kill_list = kill_list.decode('utf-8').rstrip().split("\n")
+
+        print("Stopping the container..")
+        print("Please wait for this process to finish")
+
+        # Stop all the running containers
+        proc = subprocess.Popen(["docker", "stop", ' '.join(kill_list)])
+        proc.wait()
 
 def task_build():
     """Build the Docker image for the current project"""
@@ -21,13 +37,13 @@ def task_remove():
 def task_dev():
     """Run the main task for the project"""
     return {{
-        'actions': ["docker run --volume \"%s/\":/app %s" % (CONFIG["volume_path"], IMAGE)]
+        'actions': [LongRunning("docker run --volume \"%s/\":/app %s" % (CONFIG["volume_path"], IMAGE)), kill_container]
     }}
 
 def task_prod():
     """Run the main task inside a Docker container for use in production """
     return {{
-        'actions': ["docker run %s" % IMAGE],
+        'actions': [LongRunning("docker run %s" % IMAGE), kill_container],
         'task_dep': ["build"]
     }}
 

--- a/templates/new/web_dodo.py.txt
+++ b/templates/new/web_dodo.py.txt
@@ -1,10 +1,26 @@
 import os
 import sys
+import subprocess
 from surround import Config
+from doit.tools import LongRunning
 
 CONFIG = Config(os.path.dirname(__file__))
 DOIT_CONFIG = {{'verbosity':2}}
 IMAGE = "%s/%s:%s" % (CONFIG["company"], CONFIG["image"], CONFIG["version"])
+
+def kill_container():
+    # Generate a kill list 
+    kill_list = subprocess.check_output(["docker", "ps", "-q", "-f", "ancestor=%s" % IMAGE], shell=True)
+    
+    if kill_list:
+        kill_list = kill_list.decode('utf-8').rstrip().split("\n")
+
+        print("Stopping the container..")
+        print("Please wait for this process to finish")
+
+        # Stop all the running containers
+        proc = subprocess.Popen(["docker", "stop", ' '.join(kill_list)])
+        proc.wait()
 
 def task_build():
     """Build the Docker image for the current project"""
@@ -21,13 +37,13 @@ def task_remove():
 def task_dev():
     """Run the main task for the project"""
     return {{
-        'actions': ["docker run -p 8080:8080 --volume \"%s/\":/app %s" % (CONFIG["volume_path"], IMAGE)]
+        'actions': [LongRunning("docker run -p 8080:8080 --volume \"%s/\":/app %s" % (CONFIG["volume_path"], IMAGE)), kill_container]
     }}
 
 def task_prod():
     """Run the main task inside a Docker container for use in production """
     return {{
-        'actions': ["docker run -p 8080:8080 %s" % IMAGE],
+        'actions': [LongRunning("docker run -p 8080:8080 %s" % IMAGE), kill_container],
         'task_dep': ["build"]
     }}
 
@@ -66,7 +82,7 @@ def task_batch_local():
 def task_web():
     """Run web mode inside the container"""
     return {{
-        'actions': ["docker run -p 8080:8080  %s python3 -m {project_name} --mode web" % IMAGE]
+        'actions': [LongRunning("docker run -p 8080:8080  %s python3 -m {project_name} --mode web" % IMAGE), kill_container]
     }}
 
 def task_web_local():

--- a/templates/new/web_runner.py.txt
+++ b/templates/new/web_runner.py.txt
@@ -1,5 +1,6 @@
 import json
 import logging
+import signal
 import tornado.httpserver
 import tornado.ioloop
 import tornado.options
@@ -14,18 +15,34 @@ class WebRunner(Runner):
         # Setup web service
         self.assembler.init_assembler()
         self.application = Application(self.assembler)
+        signal.signal(signal.SIGINT, self.application.signal_handler)
+
         self.application.listen(8080)
         logging.info("Server started at http://localhost:8080")
+
+        tornado.ioloop.PeriodicCallback(self.application.try_exit, 100).start()
         tornado.ioloop.IOLoop.instance().start()
 
 
 class Application(tornado.web.Application):
+    is_closing = False
+
     def __init__(self, assembler):
         handlers = [
             (r"/estimate", EstimateHandler, {{'assembler': assembler}}),
             (r"/info", InfoHandler, {{'assembler': assembler}}),
         ]
         tornado.web.Application.__init__(self, handlers)
+
+    def signal_handler(self, signum, frame):
+        logging.info('exiting...')
+        self.is_closing = True
+
+    def try_exit(self):
+        if self.is_closing:
+            # clean up here
+            tornado.ioloop.IOLoop.instance().stop()
+            logging.info('exit success')
 
 
 class EstimateHandler(tornado.web.RequestHandler):
@@ -52,4 +69,4 @@ class InfoHandler(tornado.web.RequestHandler):
         self.assembler = assembler
 
     def get(self):
-      self.write({{'version': '0.0.1'}})
+        self.write({{'version': '0.0.1'}})


### PR DESCRIPTION
When running `surround run web` on Windows, using CTRL+C doesn't stop the container, which creates problems when trying to run the command again. This PR fixes that issue. 

Will need some testing on Linux and MacOS