### PR TITLE
FIX: Convert project name when using in a generated class name

### DIFF
--- a/surround/cli.py
+++ b/surround/cli.py
@@ -201,13 +201,13 @@ def is_valid_name(aparser, arg):
     :rype: string
     """
 
-    if not arg.isalpha() or not arg.islower():
-        aparser.error("Name %s must be lowercase letters" % arg)
+    if not re.match("^[A-Za-z_]*$", arg) or not arg.islower():
+        aparser.error("Name %s must be lowercase letters and underscores only" % arg)
     else:
         return arg
 
 def make_name_safe(project_name):
-    words = re.split('_|-', project_name)
+    words = re.split('_', project_name)
     result = ''
 
     for word in words:
@@ -352,8 +352,8 @@ def parse_init_args(args):
         else:
             while True:
                 project_name = input("Name of project: ")
-                if not re.match("^[A-Za-z_-]*$", project_name) or not project_name.islower():
-                    print("error: project name requires lowercase letters and hyphens only")
+                if not re.match("^[A-Za-z_]*$", project_name) or not project_name.islower():
+                    print("error: project name requires lowercase letters and underscores only")
                 else:
                     break
 

--- a/surround/cli.py
+++ b/surround/cli.py
@@ -78,7 +78,7 @@ def process_files(files, project_dir, project_name, project_description, require
 
     for afile, content in files:
         actual_file = afile.format(project_name=project_name, project_description=project_description)
-        actual_content = content.format(project_name=project_name, project_description=project_description, version=pkg_resources.get_distribution("surround").version)
+        actual_content = content.format(project_name=project_name, safe_project_name=make_name_safe(project_name), project_description=project_description, version=pkg_resources.get_distribution("surround").version)
         file_path = os.path.join(project_dir, actual_file)
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
@@ -108,7 +108,7 @@ def process_templates(templates, folder, project_dir, project_name, project_desc
     """
 
     for afile, template, capitalize, web_component in templates:
-        actual_file = afile.format(project_name=project_name, project_description=project_description)
+        actual_file = afile.format(project_name=project_name, safe_project_name=make_name_safe(project_name), project_description=project_description)
         path = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
         if not require_web and web_component:
@@ -117,7 +117,7 @@ def process_templates(templates, folder, project_dir, project_name, project_desc
         with open(os.path.join(path, "templates", folder, template)) as f:
             contents = f.read()
             name = project_name.capitalize() if capitalize else project_name
-            actual_contents = contents.format(project_name=name, project_description=project_description)
+            actual_contents = contents.format(project_name=name, safe_project_name=make_name_safe(project_name), project_description=project_description)
             file_path = os.path.join(project_dir, actual_file)
         with open(file_path, 'w') as f:
             f.write(actual_contents)
@@ -205,6 +205,15 @@ def is_valid_name(aparser, arg):
         aparser.error("Name %s must be lowercase letters" % arg)
     else:
         return arg
+
+def make_name_safe(project_name):
+    words = re.split('_|-', project_name)
+    result = ''
+
+    for word in words:
+        result += word.capitalize()
+
+    return result
 
 def load_modules_from_path(path, module_name):
     """

--- a/surround/cli.py
+++ b/surround/cli.py
@@ -207,6 +207,14 @@ def is_valid_name(aparser, arg):
         return arg
 
 def make_name_safe(project_name):
+    """
+    Converts a name with underscores into a valid class name (PascalCase).
+    E.g. test_project will become TestProject
+
+    :param project_name: the name we want to convert
+    :type project_name: str
+    """
+
     words = re.split('_', project_name)
     result = ''
 

--- a/templates/new/batch_runner.py.txt
+++ b/templates/new/batch_runner.py.txt
@@ -1,13 +1,13 @@
 import logging
 from surround import Runner
-from stages import {project_name}Data
+from stages import {safe_project_name}Data
 
 logging.basicConfig(level=logging.INFO)
 
 class BatchRunner(Runner):
     def run(self, is_training=False):
         self.assembler.init_assembler(True)
-        data = {project_name}Data()
+        data = {safe_project_name}Data()
 
         # Load data to be processed
         raw_data = "TODO: Load raw data here"

--- a/templates/new/stages.py.txt
+++ b/templates/new/stages.py.txt
@@ -1,7 +1,7 @@
 from surround import Estimator, SurroundData, Validator
 
 
-class {project_name}Data(SurroundData):
+class {safe_project_name}Data(SurroundData):
     input_data = None
     output_data = None
 

--- a/templates/new/web_runner.py.txt
+++ b/templates/new/web_runner.py.txt
@@ -5,7 +5,7 @@ import tornado.ioloop
 import tornado.options
 import tornado.web
 from surround import Runner
-from stages import {project_name}Data
+from stages import {safe_project_name}Data
 
 logging.basicConfig(level=logging.INFO)
 
@@ -31,7 +31,7 @@ class Application(tornado.web.Application):
 class EstimateHandler(tornado.web.RequestHandler):
     def initialize(self, assembler):
         self.assembler = assembler
-        self.data = {project_name}Data()
+        self.data = {safe_project_name}Data()
 
     def post(self):
         req_data = json.loads(self.request.body)


### PR DESCRIPTION
Convert `test-project_name` to `TestProjectName` when generating project files from templates.
Can be accessed in templates using: `{safe_project_name}`

Fixes errors that occur when #110 was fixed