### PR TITLE
ENHANCE: Package version via __version__ & --version flag

### DIFF
--- a/surround/__init__.py
+++ b/surround/__init__.py
@@ -1,6 +1,10 @@
+import pkg_resources
+
 from .surround import SurroundData
 from .stage import Validator, Filter, Estimator
 from .visualiser import Visualiser
 from .config import Config
 from .assembler import Assembler
 from .runners import Runner
+
+__version__ = pkg_resources.get_distribution("surround").version

--- a/surround/cli.py
+++ b/surround/cli.py
@@ -400,6 +400,13 @@ def parse_tool_args(parsed_args, remote_parser, tool):
     else:
         parse_init_args(parsed_args)
 
+def print_version():
+    """
+    Prints the current Surround package version to the console.
+    """
+
+    print("Surround v" + pkg_resources.get_distribution("surround").version)
+
 def execute_cli():
     """
     Uses the argparse module to parse sys.argv for sub-commands and any arguments (if required).
@@ -417,6 +424,8 @@ def execute_cli():
     """
 
     parser = argparse.ArgumentParser(prog='surround', description="The Surround Command Line Interface")
+    parser.add_argument('-v', '--version', help="Show the current version of Surround")
+
     sub_parser = parser.add_subparsers(description="Surround must be called with one of the following commands")
 
     init_parser = sub_parser.add_parser('init', help="Initialise a new Surround project")
@@ -445,6 +454,8 @@ def execute_cli():
     try:
         if len(sys.argv) == 1 or sys.argv[1] in ['-h', '--help']:
             parser.print_help()
+        elif sys.argv[1] in ['-v', '--version']:
+            print_version()
         elif len(sys.argv) < 2 or not sys.argv[1] in tools:
             print("Invalid subcommand, must be one of %s" % tools)
             parser.print_help()

--- a/surround/cli.py
+++ b/surround/cli.py
@@ -424,7 +424,7 @@ def execute_cli():
     """
 
     parser = argparse.ArgumentParser(prog='surround', description="The Surround Command Line Interface")
-    parser.add_argument('-v', '--version', help="Show the current version of Surround")
+    parser.add_argument('-v', '--version', action='store_true', help="Show the current version of Surround")
 
     sub_parser = parser.add_subparsers(description="Surround must be called with one of the following commands")
 


### PR DESCRIPTION
`surround.__version__` will now return the current version e.g. `0.0.9`

The command `surround --version` will print now print:
`Surround v0.0.9` 

For issues #82 and #119 