### PR TITLE
FEATURE: Jupyter Notebook Integration

### DIFF
--- a/surround/project.py
+++ b/surround/project.py
@@ -25,6 +25,8 @@ PROJECTS = {
             ("{project_name}/__main__.py", "batch_main.py.txt", True, False),
             ("{project_name}/__main__.py", "web_main.py.txt", True, True),
             ("{project_name}/__init__.py", "init.py.txt", True, False),
+            ("notebooks/example.ipynb", "example.ipynb.txt", False, False),
+            ("notebooks/example.ipynb", "example.ipynb.txt", False, True),
             ("dodo.py", "dodo.py.txt", False, False),
             ("dodo.py", "web_dodo.py.txt", False, True),
             ("Dockerfile", "Dockerfile.txt", False, False),

--- a/templates/new/dodo.py.txt
+++ b/templates/new/dodo.py.txt
@@ -66,7 +66,7 @@ def task_batch_local():
     }}
 
 def task_jupyter():
-    command = "pip install -r /home/jovyan/work/requirements.txt; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
+    command = "rm -r work; pip install -r /home/jovyan/requirements.txt; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
     
     def run_command():
         process = subprocess.Popen([
@@ -74,7 +74,7 @@ def task_jupyter():
             "run",
             "--rm",
             "--name", "{project_name}_surround_notebook",
-            "--volume", "%s:/home/jovyan/work" % CONFIG['volume_path'], 
+            "--volume", "%s:/home/jovyan" % CONFIG['volume_path'], 
             "-p", "8888:8888",
             "--user", "root",
             "-w", "/home/jovyan",
@@ -82,12 +82,14 @@ def task_jupyter():
             "bash",  "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         print("Starting jupyter notbook server...\n")
-        print("Linux/MacOS URL: http://localhost:8888/tree/work")
-        print("Windows URL:     http://192.168.99.100:8888/tree/work\n")
+        print("Linux/MacOS URL: http://localhost:8888/tree")
+        print("Windows URL:     http://192.168.99.100:8888/tree\n")
         print("Use CTRL+C to stop the server.")
 
         try:
             process.wait()
+        except KeyboardInterrupt:
+            pass
         finally:
             print("Closing server... (if this happened instantly, an error occured, check if Docker is running)")
             process = subprocess.Popen(['docker', 'stop', '{project_name}_surround_notebook'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/templates/new/dodo.py.txt
+++ b/templates/new/dodo.py.txt
@@ -1,5 +1,6 @@
 import os
 import sys
+import subprocess
 from surround import Config
 
 CONFIG = Config(os.path.dirname(__file__))
@@ -62,4 +63,36 @@ def task_batch_local():
     return {{
         'basename': 'batchLocal',
         'actions': ["%s -m %s --mode batch" % (sys.executable, PACKAGE_PATH)]
+    }}
+
+def task_jupyter():
+    command = "pip install -r /home/jovyan/work/requirements.txt; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
+    
+    def run_command():
+        process = subprocess.Popen([
+            "docker", 
+            "run",
+            "--rm",
+            "--name", "{project_name}_surround_notebook",
+            "--volume", "%s:/home/jovyan/work" % CONFIG['volume_path'], 
+            "-p", "8888:8888",
+            "--user", "root",
+            "-w", "/home/jovyan",
+            "jupyter/base-notebook:307ad2bb5fce", 
+            "bash",  "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        print("Starting jupyter notbook server...\n")
+        print("Linux/MacOS URL: http://localhost:8888/tree/work")
+        print("Windows URL:     http://192.168.99.100:8888/tree/work\n")
+        print("Use CTRL+C to stop the server.")
+
+        try:
+            process.wait()
+        finally:
+            print("Closing server... (if this happened instantly, an error occured, check if Docker is running)")
+            process = subprocess.Popen(['docker', 'stop', '{project_name}_surround_notebook'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            process.wait()
+    
+    return {{
+        'actions': [run_command]
     }}

--- a/templates/new/dodo.py.txt
+++ b/templates/new/dodo.py.txt
@@ -66,7 +66,7 @@ def task_batch_local():
     }}
 
 def task_jupyter():
-    command = "rm -r work; pip install -r /home/jovyan/requirements.txt; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
+    command = "pip install -r /app/requirements.txt; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
     
     def run_command():
         process = subprocess.Popen([
@@ -74,10 +74,10 @@ def task_jupyter():
             "run",
             "--rm",
             "--name", "{project_name}_surround_notebook",
-            "--volume", "%s:/home/jovyan" % CONFIG['volume_path'], 
+            "--volume", "%s:/app" % CONFIG['volume_path'], 
             "-p", "55910:8888",
             "--user", "root",
-            "-w", "/home/jovyan",
+            "-w", "/app",
             "jupyter/base-notebook:307ad2bb5fce", 
             "bash",  "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 

--- a/templates/new/dodo.py.txt
+++ b/templates/new/dodo.py.txt
@@ -75,15 +75,15 @@ def task_jupyter():
             "--rm",
             "--name", "{project_name}_surround_notebook",
             "--volume", "%s:/home/jovyan" % CONFIG['volume_path'], 
-            "-p", "8888:8888",
+            "-p", "55910:8888",
             "--user", "root",
             "-w", "/home/jovyan",
             "jupyter/base-notebook:307ad2bb5fce", 
             "bash",  "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         print("Starting jupyter notbook server...\n")
-        print("Linux/MacOS URL: http://localhost:8888/tree")
-        print("Windows URL:     http://192.168.99.100:8888/tree\n")
+        print("Linux/MacOS URL: http://localhost:55910/tree")
+        print("Windows URL:     http://192.168.99.100:55910/tree\n")
         print("Use CTRL+C to stop the server.")
 
         try:

--- a/templates/new/dodo.py.txt
+++ b/templates/new/dodo.py.txt
@@ -68,7 +68,7 @@ def task_batch_local():
     }}
 
 def task_jupyter():
-    command = "pip install -r /app/requirements.txt; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
+    command = "pip install -r /app/requirements.txt; mkdir /etc/ipython; echo \"c.InteractiveShellApp.extensions.append('autoreload')\nc.InteractiveShellApp.exec_lines = ['%autoreload 2', 'import sys', 'sys.path.append(\\'../\\')']\" > /etc/ipython/ipython_config.py; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
     
     def run_command():
         process = subprocess.Popen([

--- a/templates/new/dodo.py.txt
+++ b/templates/new/dodo.py.txt
@@ -1,6 +1,8 @@
 import os
 import sys
 import subprocess
+import re
+import webbrowser
 from surround import Config
 
 CONFIG = Config(os.path.dirname(__file__))
@@ -79,11 +81,38 @@ def task_jupyter():
             "--user", "root",
             "-w", "/app",
             "jupyter/base-notebook:307ad2bb5fce", 
-            "bash",  "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            "bash",  "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
 
         print("Starting jupyter notbook server...\n")
-        print("Linux/MacOS URL: http://localhost:55910/tree")
-        print("Windows URL:     http://192.168.99.100:55910/tree\n")
+        
+        # Get the IP address of the container, otherwise use localhost
+        ip_process = subprocess.Popen(['docker-machine', 'ip'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
+        ip_process.wait()
+
+        ip_output = ip_process.stdout.readline().rstrip()
+
+        if re.match(r"^(\d{{1,3}}\.){{3}}\d{{1,3}}$", ip_output):
+            host = ip_output
+        else:
+            host = "localhost"
+
+        # Wait for the notebook server to be up before loading browser
+        while True:
+            line = process.stderr.readline().rstrip() 
+            if line and 'Serving notebooks from local directory' in line:
+                break
+            elif process.poll():
+                print("Failed to start the server, check if its not running somewhere else!")
+
+                # Stop any containers that might be running
+                process = subprocess.Popen(['docker', 'stop', '{project_name}_surround_notebook'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                process.wait()
+                return
+
+        # Open the browser automatically
+        webbrowser.open('http://%s:55910/tree' % host, new=2)
+
+        print("Notebook URL: http://%s:55910/tree\n" % host)
         print("Use CTRL+C to stop the server.")
 
         try:
@@ -91,7 +120,7 @@ def task_jupyter():
         except KeyboardInterrupt:
             pass
         finally:
-            print("Closing server... (if this happened instantly, an error occured, check if Docker is running)")
+            print("Closing server...")
             process = subprocess.Popen(['docker', 'stop', '{project_name}_surround_notebook'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             process.wait()
     

--- a/templates/new/example.ipynb.txt
+++ b/templates/new/example.ipynb.txt
@@ -1,0 +1,46 @@
+{{
+ "cells": [
+  {{
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {{}},
+   "outputs": [],
+   "source": [
+    "# Every notebook must have this at the beginning so you can import from the project\n",
+    "import sys\n",
+    "sys.path.append(\"../\")"
+   ]
+  }},
+  {{
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {{}},
+   "outputs": [],
+   "source": [
+    "# Example importing code from the Surround project\n",
+    "from {project_name}.stages import Main"
+   ]
+  }}
+ ],
+ "metadata": {{
+  "kernelspec": {{
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }},
+  "language_info": {{
+   "codemirror_mode": {{
+    "name": "ipython",
+    "version": 3
+   }},
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }}
+ }},
+ "nbformat": 4,
+ "nbformat_minor": 2
+}}

--- a/templates/new/example.ipynb.txt
+++ b/templates/new/example.ipynb.txt
@@ -2,17 +2,6 @@
  "cells": [
   {{
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {{}},
-   "outputs": [],
-   "source": [
-    "# Every notebook must have this at the beginning so you can import from the project\n",
-    "import sys\n",
-    "sys.path.append(\"../\")"
-   ]
-  }},
-  {{
-   "cell_type": "code",
    "execution_count": 7,
    "metadata": {{}},
    "outputs": [],

--- a/templates/new/web_dodo.py.txt
+++ b/templates/new/web_dodo.py.txt
@@ -1,6 +1,8 @@
 import os
 import sys
 import subprocess
+import re
+import webbrowser
 from surround import Config
 
 CONFIG = Config(os.path.dirname(__file__))
@@ -92,11 +94,38 @@ def task_jupyter():
             "--user", "root",
             "-w", "/app",
             "jupyter/base-notebook:307ad2bb5fce", 
-            "bash",  "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            "bash",  "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
 
         print("Starting jupyter notbook server...\n")
-        print("Linux/MacOS URL: http://localhost:55910/tree")
-        print("Windows URL:     http://192.168.99.100:55910/tree\n")
+        
+        # Get the IP address of the container, otherwise use localhost
+        ip_process = subprocess.Popen(['docker-machine', 'ip'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8')
+        ip_process.wait()
+
+        ip_output = ip_process.stdout.readline().rstrip()
+
+        if re.match(r"^(\d{{1,3}}\.){{3}}\d{{1,3}}$", ip_output):
+            host = ip_output
+        else:
+            host = "localhost"
+
+        # Wait for the notebook server to be up before loading browser
+        while True:
+            line = process.stderr.readline().rstrip() 
+            if line and 'Serving notebooks from local directory' in line:
+                break
+            elif process.poll():
+                print("Failed to start the server, please try again!")
+
+                # Stop any containers that might be running
+                process = subprocess.Popen(['docker', 'stop', '{project_name}_surround_notebook'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                process.wait()
+                return
+
+        # Open the browser automatically
+        webbrowser.open('http://%s:55910/tree' % host, new=2)
+
+        print("Notebook URL: http://%s:55910/tree\n" % host)
         print("Use CTRL+C to stop the server.")
 
         try:
@@ -104,7 +133,7 @@ def task_jupyter():
         except KeyboardInterrupt:
             pass
         finally:
-            print("Closing server... (if this happened instantly, an error occured, check if Docker is running)")
+            print("Closing server...")
             process = subprocess.Popen(['docker', 'stop', '{project_name}_surround_notebook'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             process.wait()
     

--- a/templates/new/web_dodo.py.txt
+++ b/templates/new/web_dodo.py.txt
@@ -81,7 +81,7 @@ def task_web_local():
     }}
 
 def task_jupyter():
-    command = "pip install -r /app/requirements.txt; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
+    command = "pip install -r /app/requirements.txt; mkdir /etc/ipython; echo \"c.InteractiveShellApp.extensions.append('autoreload')\nc.InteractiveShellApp.exec_lines = ['%autoreload 2', 'import sys', 'sys.path.append(\\'../\\')']\" > /etc/ipython/ipython_config.py; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
     
     def run_command():
         process = subprocess.Popen([

--- a/templates/new/web_dodo.py.txt
+++ b/templates/new/web_dodo.py.txt
@@ -88,15 +88,15 @@ def task_jupyter():
             "--rm",
             "--name", "{project_name}_surround_notebook",
             "--volume", "%s:/home/jovyan" % CONFIG['volume_path'], 
-            "-p", "8888:8888",
+            "-p", "55910:8888",
             "--user", "root",
             "-w", "/home/jovyan",
             "jupyter/base-notebook:307ad2bb5fce", 
             "bash",  "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         print("Starting jupyter notbook server...\n")
-        print("Linux/MacOS URL: http://localhost:8888/tree")
-        print("Windows URL:     http://192.168.99.100:8888/tree\n")
+        print("Linux/MacOS URL: http://localhost:55910/tree")
+        print("Windows URL:     http://192.168.99.100:55910/tree\n")
         print("Use CTRL+C to stop the server.")
 
         try:

--- a/templates/new/web_dodo.py.txt
+++ b/templates/new/web_dodo.py.txt
@@ -79,7 +79,7 @@ def task_web_local():
     }}
 
 def task_jupyter():
-    command = "pip install -r /home/jovyan/work/requirements.txt; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
+    command = "rm -r work; pip install -r /home/jovyan/requirements.txt; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
     
     def run_command():
         process = subprocess.Popen([
@@ -87,7 +87,7 @@ def task_jupyter():
             "run",
             "--rm",
             "--name", "{project_name}_surround_notebook",
-            "--volume", "%s:/home/jovyan/work" % CONFIG['volume_path'], 
+            "--volume", "%s:/home/jovyan" % CONFIG['volume_path'], 
             "-p", "8888:8888",
             "--user", "root",
             "-w", "/home/jovyan",
@@ -95,12 +95,14 @@ def task_jupyter():
             "bash",  "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         print("Starting jupyter notbook server...\n")
-        print("Linux/MacOS URL: http://localhost:8888/tree/work")
-        print("Windows URL:     http://192.168.99.100:8888/tree/work\n")
+        print("Linux/MacOS URL: http://localhost:8888/tree")
+        print("Windows URL:     http://192.168.99.100:8888/tree\n")
         print("Use CTRL+C to stop the server.")
 
         try:
             process.wait()
+        except KeyboardInterrupt:
+            pass
         finally:
             print("Closing server... (if this happened instantly, an error occured, check if Docker is running)")
             process = subprocess.Popen(['docker', 'stop', '{project_name}_surround_notebook'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/templates/new/web_dodo.py.txt
+++ b/templates/new/web_dodo.py.txt
@@ -1,5 +1,6 @@
 import os
 import sys
+import subprocess
 from surround import Config
 
 CONFIG = Config(os.path.dirname(__file__))
@@ -75,4 +76,36 @@ def task_web_local():
     return {{
         'basename': 'webLocal',
         'actions': ["%s -m %s --mode web" % (sys.executable, PACKAGE_PATH)]
+    }}
+
+def task_jupyter():
+    command = "pip install -r /home/jovyan/work/requirements.txt; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
+    
+    def run_command():
+        process = subprocess.Popen([
+            "docker", 
+            "run",
+            "--rm",
+            "--name", "{project_name}_surround_notebook",
+            "--volume", "%s:/home/jovyan/work" % CONFIG['volume_path'], 
+            "-p", "8888:8888",
+            "--user", "root",
+            "-w", "/home/jovyan",
+            "jupyter/base-notebook:307ad2bb5fce", 
+            "bash",  "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        print("Starting jupyter notbook server...\n")
+        print("Linux/MacOS URL: http://localhost:8888/tree/work")
+        print("Windows URL:     http://192.168.99.100:8888/tree/work\n")
+        print("Use CTRL+C to stop the server.")
+
+        try:
+            process.wait()
+        finally:
+            print("Closing server... (if this happened instantly, an error occured, check if Docker is running)")
+            process = subprocess.Popen(['docker', 'stop', '{project_name}_surround_notebook'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            process.wait()
+    
+    return {{
+        'actions': [run_command]
     }}

--- a/templates/new/web_dodo.py.txt
+++ b/templates/new/web_dodo.py.txt
@@ -79,7 +79,7 @@ def task_web_local():
     }}
 
 def task_jupyter():
-    command = "rm -r work; pip install -r /home/jovyan/requirements.txt; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
+    command = "pip install -r /app/requirements.txt; /usr/local/bin/start.sh jupyter notebook --NotebookApp.token=''"
     
     def run_command():
         process = subprocess.Popen([
@@ -87,10 +87,10 @@ def task_jupyter():
             "run",
             "--rm",
             "--name", "{project_name}_surround_notebook",
-            "--volume", "%s:/home/jovyan" % CONFIG['volume_path'], 
+            "--volume", "%s:/app" % CONFIG['volume_path'], 
             "-p", "55910:8888",
             "--user", "root",
-            "-w", "/home/jovyan",
+            "-w", "/app",
             "jupyter/base-notebook:307ad2bb5fce", 
             "bash",  "-c", command], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 


### PR DESCRIPTION
Implements feature #168 
Starts the Jupyter Notebook App in a Docker container, so Docker must be running for this command to work.

Use command: 
```
$ surround run jupyter
Project tasks:
.  jupyter
Starting jupyter notbook server...

Linux/MacOS URL: http://localhost:8888/tree/work
Windows URL:     http://192.168.99.100:8888/tree/work

Use CTRL+C to stop the server.
```

Notebooks must have the following at the beginning if you want to import project modules:
```python
import sys
sys.path.append("../")
```