### PR TITLE
FIX: Ensure data/ is renamed to input/ in generated projects

### DIFF
--- a/surround/project.py
+++ b/surround/project.py
@@ -2,7 +2,7 @@ PROJECTS = {
     "new" : {
         "dirs" : [
             ".surround",
-            "data",
+            "input",
             "output",
             "docs",
             "models",


### PR DESCRIPTION
Looks like this was lost when rebasing the renaming PR