### PR TITLE
FIX: Allow boolean config properties to be set in environment variables

### DIFF
--- a/surround/config.py
+++ b/surround/config.py
@@ -289,7 +289,20 @@ class Config(Mapping):
             if new_key in config:
                 the_type = type(config[new_key])
             else:
-                the_type = type(ast.literal_eval(value))
+                try:
+                    the_type = type(ast.literal_eval(value))
+                    if the_type == bool:
+                        value = ast.literal_eval(value)
+                except Exception:
+                    if value.lower() == "true":
+                        value = True
+                        the_type = bool
+                    elif value.lower() == "false":
+                        value = False
+                        the_type = bool
+                    else:
+                        the_type = str
+
             config[new_key] = the_type(value)
         return config
 

--- a/surround/tests/config_test.py
+++ b/surround/tests/config_test.py
@@ -100,9 +100,19 @@ class TestConfig(unittest.TestCase):
     def test_env_config(self):
         with patch.dict('os.environ', {
                 'SURROUND_MAIN_COUNT': str(45),
-                'SURROUND_TEMP': str(0.3)
+                'SURROUND_TEMP': str(0.3),
+                'SURROUND_STRING': "this is a test string",
+                'SURROUND_BOOL': "true",
+                'SURROUND_BOOLTWO': "false",
+                "SURROUND_BOOLTHREE": "True",
+                "SURROUND_BOOLFOUR": "False"
         }):
             config = Config()
             config.read_from_dict(yaml.safe_load(yaml3))
             self.assertEqual(config["main"]["count"], 45)
             self.assertEqual(config["temp"], 0.3)
+            self.assertEqual(config["string"], "this is a test string")
+            self.assertTrue(config["bool"])
+            self.assertFalse(config["booltwo"])
+            self.assertTrue(config["boolthree"])
+            self.assertFalse(config["boolfour"])


### PR DESCRIPTION
Fixes the following situation:

When `SURROUND_TEST_VAR="False"` was set in environment variables, the Config would output this:
```
>>> config["test"]["var"]
True
```

Also fixes:

When `SURROUND_TEST_VAR="This is a string"` was set in environment variables, the Config class would throw the following exception:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\python364\lib\ast.py", line 85, in literal_eval
    return _convert(node_or_string)
  File "C:\python364\lib\ast.py", line 84, in _convert
    raise ValueError('malformed node or string: ' + repr(node))
ValueError: malformed node or string: <_ast.Name object at 0x02D03F50>
```