### PR TITLE
ENHANCE: Make Config a singleton

### DIFF
--- a/surround/__init__.py
+++ b/surround/__init__.py
@@ -4,7 +4,7 @@ from .surround import Surround
 from .state import State
 from .stage import Validator, Filter, Estimator
 from .visualiser import Visualiser
-from .config import Config
+from .config import Config, has_config
 from .assembler import Assembler
 from .runners import Runner, RunMode
 

--- a/surround/assembler.py
+++ b/surround/assembler.py
@@ -7,7 +7,7 @@ import logging
 from abc import ABC
 from datetime import datetime
 
-from .config import Config
+from .config import has_config
 from .stage import Filter, Estimator, Validator
 from .visualiser import Visualiser
 
@@ -57,7 +57,8 @@ class Assembler(ABC):
     """
 
     # pylint: disable=too-many-instance-attributes
-    def __init__(self, assembler_name=""):
+    @has_config
+    def __init__(self, assembler_name="", config=None):
         """
         Constructor for an Assembler pipeline:
 
@@ -66,7 +67,7 @@ class Assembler(ABC):
         """
 
         self.assembler_name = assembler_name
-        self.config = Config(auto_load=True)
+        self.config = config
         self.stages = None
         self.estimator = None
         self.validator = None

--- a/surround/assembler.py
+++ b/surround/assembler.py
@@ -7,7 +7,7 @@ import logging
 from abc import ABC
 from datetime import datetime
 
-from .config import has_config
+from .config import Config, has_config
 from .stage import Filter, Estimator, Validator
 from .visualiser import Visualiser
 

--- a/surround/config.py
+++ b/surround/config.py
@@ -1,5 +1,6 @@
 import ast
 import os
+import functools
 
 from pathlib import Path
 from collections.abc import Mapping
@@ -50,6 +51,19 @@ class Config(Mapping):
 
         SURRROUND_PREDICT_DEBUG=False
     """
+
+    __instance = None
+
+    @staticmethod
+    def instance():
+        """
+        Static method which returns the a singleton instance of Config.
+        """
+
+        if not Config.__instance:
+            Config.__instance = Config(auto_load=True)
+
+        return Config.__instance
 
     def __init__(self, project_root=None, package_path=None, auto_load=False):
         """
@@ -373,3 +387,16 @@ class Config(Mapping):
         """
 
         return len(self._storage)
+
+def has_config(func):
+    """
+    Decorator that injects the singleton config instance into the arguments of the
+    function.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        kwargs["config"] = Config.instance()
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/surround/config.py
+++ b/surround/config.py
@@ -388,15 +388,31 @@ class Config(Mapping):
 
         return len(self._storage)
 
-def has_config(func):
+def has_config(func=None, name="config"):
     """
-    Decorator that injects the singleton config instance into the arguments of the
-    function.
+    Decorator that injects the singleton config instance into the arguments of the function.
+    e.g.
+    ```
+        @has_config
+        def some_func(config):
+            value = config.get_path("some.config")
+            ...
+
+        @has_config(name="global_config")
+        def other_func(global_config, local_config):
+            value = config.get_path("some.config")
+    ```
     """
 
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        kwargs["config"] = Config.instance()
+    def function_wrapper(*args, **kwargs):
+        kwargs[name] = Config.instance()
         return func(*args, **kwargs)
 
-    return wrapper
+    if func:
+        return function_wrapper
+
+    def recursive_wrapper(func):
+        return has_config(func, name)
+
+    return recursive_wrapper

--- a/surround/config.py
+++ b/surround/config.py
@@ -412,7 +412,7 @@ def has_config(func=None, name="config", filename=None):
     def function_wrapper(*args, **kwargs):
         config = Config.instance()
         if filename:
-            path = os.path.join(config["package_path"], filename)
+            path = os.path.join(config.get_path("package_path"), filename)
             config.read_config_files([path])
         kwargs[name] = config
         return func(*args, **kwargs)

--- a/templates/new/batch_main.py.txt
+++ b/templates/new/batch_main.py.txt
@@ -5,7 +5,7 @@ Runners and assemblies are defined in here.
 
 import os
 import argparse
-from surround import Surround, Assembler, Config
+from surround import Surround, Assembler, has_config
 from .stages import Baseline, InputValidator, ReportGenerator
 from .file_system_runner import FileSystemRunner
 
@@ -20,8 +20,8 @@ ASSEMBLIES = [
         .set_visualiser(ReportGenerator())
 ]
 
-def main():
-    config = Config(auto_load=True)
+@has_config
+def main(config=None):
     default_runner = config.get_path('runner.default')
     default_assembler = config.get_path('assembler.default')
 

--- a/templates/new/web_main.py.txt
+++ b/templates/new/web_main.py.txt
@@ -23,7 +23,7 @@ ASSEMBLIES = [
 ]
 
 @has_config
-def main(config):
+def main(config=None):
     default_runner = config.get_path('runner.default')
     default_assembler = config.get_path('assembler.default')
 

--- a/templates/new/web_main.py.txt
+++ b/templates/new/web_main.py.txt
@@ -5,7 +5,7 @@ Runners and ASSEMBLIES are defined in here.
 
 import os
 import argparse
-from surround import Surround, Assembler, Config
+from surround import Surround, Assembler, has_config
 from .stages import Baseline, InputValidator, ReportGenerator
 from .file_system_runner import FileSystemRunner
 from .web_runner import WebRunner
@@ -22,8 +22,8 @@ ASSEMBLIES = [
         .set_visualiser(ReportGenerator())
 ]
 
-def main():
-    config = Config(auto_load=True)
+@has_config
+def main(config):
     default_runner = config.get_path('runner.default')
     default_assembler = config.get_path('assembler.default')
 


### PR DESCRIPTION
Example:
```python
from surround import has_config

@has_config
def some_function(config=None):
    config.read_from_dict({"override": False})

@has_config(name="local_config")
def some_other_function(local_config=None):
    assert(local_config["override"]) == False)
```

Also can be used like this if preferred:
```python
config = Config.instance()
```

Can also be used to override:
```python
@has_config(filename="override.yaml")
def some_function(config=None):
    ...
```