### PR TITLE
FIX: WebRunner predict endpoint crash

### DIFF
--- a/templates/new/web_runner.py.txt
+++ b/templates/new/web_runner.py.txt
@@ -35,16 +35,15 @@ class Application(tornado.web.Application):
 class EstimateHandler(tornado.web.RequestHandler):
     def initialize(self, assembler):
         self.assembler = assembler
-        self.data = AssemblerState()
 
     def post(self):
         req_data = json.loads(self.request.body)
 
+        # Prepare input_data for the assembler
+        self.data = AssemblerState(req_data["message"])
+
         # Clean output_data on every request
         self.data.output_data = ""
-
-        # Prepare input_date for the assembler
-        self.data.input_data = req_data["message"]
 
         # Execute assembler
         self.assembler.run(self.data)


### PR DESCRIPTION
When generating a project with webrunner, sending a POST request crashed the process. This was due to the AssemblerState being initialised with no value for input_data. Moved the initialisation to post method to allow for input data to be passed in.