### PR TITLE
FIX: GH Actions trigger for release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,8 @@ on:
     branches:
       - main
     tags:
-      - "v+[0-9]+.[0-9]+.[0-9]*$"
+      - "surround-v+[0-9]+.[0-9]+.[0-9]*$"
+      - "surround-cli-v+[0-9]+.[0-9]+.[0-9]*$"
 
 # Cancel in-progress workflow runs on new PR commits.
 concurrency:


### PR DESCRIPTION
Tried to do a release for the CLI tool but nothing happened.